### PR TITLE
fix: stabilize rendering on release/profile builds with Impeller

### DIFF
--- a/lib/src/widgets/liquid_glass.dart
+++ b/lib/src/widgets/liquid_glass.dart
@@ -10,6 +10,13 @@ import 'utils/liquid_glass_refraction_mode.dart';
 
 // Represents a single lens in the LiquidGlass system
 class LiquidGlass {
+  /// Optional widget key, propagated to the underlying `LiquidGlassWidget`
+  /// inside `LiquidGlassView`. Use it to bind a lens `State` to a logical
+  /// slot (e.g. a fixed UI position) rather than to its index in `children`.
+  /// Without a stable key, inserting/removing other lenses (e.g. a progress
+  /// bar) can cause Flutter to reuse the wrong `State` for a lens.
+  final Key? key;
+
   /// Controls the lens behavior programmatically, such as toggling visibility or
   /// updating properties dynamically at runtime.
   final LiquidGlassController? controller;
@@ -127,7 +134,8 @@ class LiquidGlass {
   final bool outOfBoundaries;
 
   const LiquidGlass(
-      {this.controller,
+      {this.key,
+      this.controller,
       this.width = 200,
       this.height = 100,
       this.magnification = 1,
@@ -254,6 +262,7 @@ class _LiquidGlassWidgetState extends State<LiquidGlassWidget>
   @override
   void didUpdateWidget(covariant LiquidGlassWidget oldWidget) {
     super.didUpdateWidget(oldWidget);
+
     // If config changes and no animation is running → update instantly
     if (!_animController.isAnimating &&
         widget.config.visibility != oldWidget.config.visibility) {

--- a/lib/src/widgets/liquid_glass_view.dart
+++ b/lib/src/widgets/liquid_glass_view.dart
@@ -145,8 +145,8 @@ class _LiquidGlassViewState extends State<LiquidGlassView>
     super.didUpdateWidget(oldWidget);
     // If config changes and no animation is running → update instantly
 
-    if (isWeb && widget.children.length != oldWidget.children.length) {
-      _recreateWebShaders(widget.children.length);
+    if (widget.children.length != oldWidget.children.length) {
+      _recreateShaders(widget.children.length);
     }
     if (widget.realTimeCapture != oldWidget.realTimeCapture) {
       _realtimeCaptureEnabled = widget.realTimeCapture;
@@ -191,24 +191,21 @@ class _LiquidGlassViewState extends State<LiquidGlassView>
     final main = _mainProgram!;
     final border = _borderProgram!;
 
-    if (isWeb) {
-      final count = widget.children.length;
-
-      _shaders = {
-        'liquid_glass_list': _createShaderList(main, count),
-        'liquid_glass_border_list': _createShaderList(border, count),
-      };
-    } else {
-      _shaders = {
-        'liquid_glass': main.fragmentShader(),
-        'liquid_glass_border': border.fragmentShader(),
-      };
-    }
+    // Unified path for both web and native: one dedicated FragmentShader per
+    // lens. Previously native builds shared a single shader instance across
+    // all lenses. With 2+ lenses in release/Impeller, successive draw calls
+    // reused the same shader object with the last uniforms set, producing
+    // context-switch artifacts (old lens content leaking, new lens
+    // appearing transparent).
+    final count = widget.children.length;
+    _shaders = {
+      'liquid_glass_list': _createShaderList(main, count),
+      'liquid_glass_border_list': _createShaderList(border, count),
+    };
   }
 
-  Future<void> _recreateWebShaders(int newCount) async {
-    if (!isWeb) return;
-
+  Future<void> _recreateShaders(int newCount) async {
+    if (_mainProgram == null || _borderProgram == null) return;
     final main = _mainProgram!;
     final border = _borderProgram!;
 
@@ -219,6 +216,23 @@ class _LiquidGlassViewState extends State<LiquidGlassView>
     });
   }
 
+  /// Safely captures the background RepaintBoundary.
+  ///
+  /// Important behavior (please keep — do not remove without testing on
+  /// release/profile builds on Android):
+  /// - On release/profile builds with Impeller (Android), a
+  ///   `RenderRepaintBoundary` can still have no composited `layer` even
+  ///   after `endOfFrame` (especially for small or freshly mounted
+  ///   boundaries, or ones containing `Image.file`). In that case
+  ///   `toImageSync` throws "Null check operator used on a null value".
+  /// - So we first check `boundary.layer != null`; if the layer is not
+  ///   ready we go straight to the async `toImage()`, which can wait for
+  ///   composition to complete.
+  /// - If `toImageSync` still throws, we catch it and also fall back to
+  ///   async `toImage()`.
+  /// - If async `toImage()` also fails, we soft-fail — we do not crash
+  ///   the app; the frame is simply skipped and the UI keeps using the
+  ///   previous `_image`.
   Future<void> _captureWidgetSafe() async {
     try {
       final context = _repaintKey.currentContext;
@@ -227,25 +241,47 @@ class _LiquidGlassViewState extends State<LiquidGlassView>
       final boundary = context.findRenderObject();
       if (boundary is RenderRepaintBoundary && boundary.attached) {
         await WidgetsBinding.instance.endOfFrame;
-        if (context.mounted) {
-          double devicePixelRatio = MediaQuery.of(context).devicePixelRatio;
-          double pixelRatio =
-              widget.pixelRatio <= 0 ? devicePixelRatio : widget.pixelRatio;
-          if (pixelRatio > devicePixelRatio) {
-            pixelRatio = devicePixelRatio;
+        if (!context.mounted) return;
+
+        double devicePixelRatio = MediaQuery.of(context).devicePixelRatio;
+        double pixelRatio =
+            widget.pixelRatio <= 0 ? devicePixelRatio : widget.pixelRatio;
+        if (pixelRatio > devicePixelRatio) {
+          pixelRatio = devicePixelRatio;
+        }
+
+        // ignore: invalid_use_of_protected_member
+        final bool layerReady = boundary.layer != null;
+        final bool preferSync = widget.useSync && layerReady;
+
+        ui.Image? newImage;
+
+        if (preferSync) {
+          try {
+            newImage = boundary.toImageSync(pixelRatio: pixelRatio);
+          } catch (_) {
+            try {
+              newImage = await boundary.toImage(pixelRatio: pixelRatio);
+            } catch (_) {
+              newImage = null;
+            }
           }
-          if (widget.useSync) {
-            _image = boundary.toImageSync(
-              pixelRatio: pixelRatio,
-            );
-          } else {
-            _image = await boundary.toImage(
-              pixelRatio: pixelRatio,
-            );
+        } else {
+          try {
+            newImage = await boundary.toImage(pixelRatio: pixelRatio);
+          } catch (_) {
+            newImage = null;
           }
         }
+
+        if (newImage == null) return;
+        if (!context.mounted) return;
+
+        _image = newImage;
       }
-    } catch (_) {}
+    } catch (_) {
+      // Soft-fail: skip this frame, the UI keeps working.
+    }
   }
 
   Future<void> _captureOnce() async {
@@ -285,21 +321,28 @@ class _LiquidGlassViewState extends State<LiquidGlassView>
             builder: (context, s) {
               return Stack(children: [
                 ...widget.children.asMap().entries.map((entry) {
-                  if (_shaders.length > 1 && _image != null) {
+                  final shaderList =
+                      _shaders['liquid_glass_list'] as List<ui.FragmentShader>?;
+                  final borderList = _shaders['liquid_glass_border_list']
+                      as List<ui.FragmentShader>?;
+                  if (shaderList != null &&
+                      borderList != null &&
+                      entry.key < shaderList.length &&
+                      entry.key < borderList.length &&
+                      _image != null) {
                     final index = entry.key;
                     final child = entry.value;
 
+                    // Use `config.key` when provided, otherwise a stable
+                    // index-based key. This prevents Flutter from reusing
+                    // a lens `State` across the wrong slot when `children`
+                    // change (insert/remove/reorder).
                     return LiquidGlassWidget(
+                      key: child.key ?? ValueKey('lg_index_$index'),
                       config: child,
                       parentSize: captureSize,
-                      sharedShader: isWeb
-                          ? (_shaders['liquid_glass_list']
-                              as List<ui.FragmentShader>)[index]
-                          : _shaders['liquid_glass'],
-                      border: isWeb
-                          ? (_shaders['liquid_glass_border_list']
-                              as List<ui.FragmentShader>)[index]
-                          : _shaders['liquid_glass_border'],
+                      sharedShader: shaderList[index],
+                      border: borderList[index],
                       sharedImage: _image!,
                     );
                   } else {

--- a/lib/src/widgets/painters/liquid_glass_painter.dart
+++ b/lib/src/widgets/painters/liquid_glass_painter.dart
@@ -208,6 +208,61 @@ class LiquidGlassPainter extends CustomPainter {
 
   @override
   bool shouldRepaint(covariant LiquidGlassPainter oldDelegate) {
-    return (oldDelegate.image != image) || (borderAlpha > 0 && borderAlpha < 1);
+    // IMPORTANT (do not shorten this list): the previous implementation
+    // compared only `image` and `borderAlpha` and ignored changes to
+    // `lensWidth`/`lensHeight`/`cornerRadius`/`color` and other uniforms.
+    // In debug builds this was masked by the fact that `_image` changes
+    // every frame (so the canvas would repaint regardless). On release
+    // builds with Impeller, `toImageSync` can silently fail, so the image
+    // stops changing — and the canvas shader then freezes with stale
+    // uniforms even though the widget tree already holds a different
+    // lens configuration. That's what caused "stale lens content" and
+    // "transparent lenses" on release/profile builds.
+    //
+    // Comparing every parameter guarantees that any real change to the
+    // lens configuration triggers a repaint.
+    return oldDelegate.image != image ||
+        oldDelegate.dragOffset != dragOffset ||
+        oldDelegate.lensWidth != lensWidth ||
+        oldDelegate.lensHeight != lensHeight ||
+        oldDelegate.magnification != magnification ||
+        oldDelegate.distortion != distortion ||
+        oldDelegate.distortionWidth != distortionWidth ||
+        oldDelegate.diagonalFlip != diagonalFlip ||
+        oldDelegate.enableInnerRadiusTransparent !=
+            enableInnerRadiusTransparent ||
+        oldDelegate.parentSize != parentSize ||
+        !_shapeEquals(oldDelegate.border, border) ||
+        oldDelegate.borderAlpha != borderAlpha ||
+        oldDelegate.blur.sigmaX != blur.sigmaX ||
+        oldDelegate.blur.sigmaY != blur.sigmaY ||
+        oldDelegate.color != color ||
+        oldDelegate.chromaticAberration != chromaticAberration ||
+        oldDelegate.saturation != saturation ||
+        oldDelegate.refractionMode != refractionMode ||
+        oldDelegate.shader != shader ||
+        oldDelegate.borderShader != borderShader;
+  }
+
+  bool _shapeEquals(LiquidGlassShape? a, LiquidGlassShape? b) {
+    if (identical(a, b)) return true;
+    if (a == null || b == null) return false;
+    if (a.runtimeType != b.runtimeType) return false;
+    if (a.borderWidth != b.borderWidth) return false;
+    if (a.borderSoftness != b.borderSoftness) return false;
+    if (a.borderColor != b.borderColor) return false;
+    if (a.lightIntensity != b.lightIntensity) return false;
+    if (a.lightColor != b.lightColor) return false;
+    if (a.shadowColor != b.shadowColor) return false;
+    if (a.lightDirection != b.lightDirection) return false;
+    if (a.oneSideLightIntensity != b.oneSideLightIntensity) return false;
+    if (a.lightMode != b.lightMode) return false;
+    if (a is RoundedRectangleShape && b is RoundedRectangleShape) {
+      return a.cornerRadius == b.cornerRadius;
+    }
+    if (a is SuperellipseShape && b is SuperellipseShape) {
+      return a.curveExponent == b.curveExponent;
+    }
+    return true;
   }
 }


### PR DESCRIPTION
Fixes several issues that only surface in AOT builds (release/profile) with Impeller on Android, where lenses could freeze with stale content, render fully transparent, or crash the app with a "Null check operator used on a null value" error from `RenderRepaintBoundary.toImageSync`.

Changes:
- LiquidGlassPainter.shouldRepaint now compares every uniform-affecting parameter (size, shape, color, distortion, blur, shaders, ...) instead of only `image`/`borderAlpha`. In debug this was masked because `_image` changed every frame; in release it caused the canvas shader to freeze with stale uniforms when background capture silently failed.
- Use one dedicated FragmentShader per lens on native (same as web). Sharing a single shader across 2+ lenses caused Impeller draw calls to reuse the last uniforms set, producing context-switch artifacts.
- LiquidGlassView._captureWidgetSafe: guard `toImageSync` with a `boundary.layer != null` check, fall back to async `toImage()` when the layer is not composited yet or when `toImageSync` throws. If the async path also fails, soft-fail and skip the frame instead of crashing.
- LiquidGlass gained an optional `Key` that LiquidGlassView propagates to the underlying LiquidGlassWidget. When missing, a stable index-based key is used. This prevents Flutter from reusing a lens `State` for the wrong slot when `children` change (insert/remove/reorder).