### PR TITLE
Fix liquid glass color channel order

### DIFF
--- a/lib/src/widgets/painters/liquid_glass_painter.dart
+++ b/lib/src/widgets/painters/liquid_glass_painter.dart
@@ -126,8 +126,8 @@ class LiquidGlassPainter extends CustomPainter {
 
     shader.setFloat(index++, border!.lightDirection);
     shader.setFloat(index++, color.r);
-    shader.setFloat(index++, color.b);
     shader.setFloat(index++, color.g);
+    shader.setFloat(index++, color.b);
     shader.setFloat(index++, color.a);
     // One-side / double-side specular highlights are classic-only:
     // in optical mode the directional term saturates the internal


### PR DESCRIPTION
## Summary

Fixes the uniform order used when passing `LiquidGlass.color` to the fragment shader.

Previously the painter passed the tint channels as `r, b, g, a`, which swapped green and blue in `u_lensColor`. This change passes them as `r, g, b, a`, matching the shader's `vec4 u_lensColor`.

## Changes

- Corrected `LiquidGlassPainter` color uniform order from `r, b, g, a` to `r, g, b, a`.