### PR TITLE
feat: add LiquidGlassFab and LiquidGlassAlertDialog widgets with scaffold integration

### DIFF
--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -1,3 +1,7 @@
 org.gradle.jvmargs=-Xmx4G -XX:MaxMetaspaceSize=2G -XX:+HeapDumpOnOutOfMemoryError
 android.useAndroidX=true
 android.enableJetifier=true
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/example/lib/fab_dialog_demo.dart
+++ b/example/lib/fab_dialog_demo.dart
@@ -1,0 +1,327 @@
+import 'package:flutter/material.dart';
+import 'package:liquid_glass_easy/liquid_glass_easy.dart';
+
+/// Interactive showcase page for [LiquidGlassFab] and [LiquidGlassAlertDialog].
+class FabAndDialogDemoPage extends StatefulWidget {
+  const FabAndDialogDemoPage({super.key});
+
+  @override
+  State<FabAndDialogDemoPage> createState() => _FabAndDialogDemoPageState();
+}
+
+class _FabAndDialogDemoPageState extends State<FabAndDialogDemoPage> {
+  bool _useExtendedFab = true;
+
+  void _openAlertDialog() {
+    showLiquidGlassDialog(
+      context: context,
+      builder: (context) => LiquidGlassAlertDialog(
+        icon: const Icon(Icons.auto_awesome_rounded, color: Color(0xFF7C5CFF), size: 36),
+        title: const Text('Liquid Glass Dialog'),
+        content: const Text(
+          'This alert dialog is rendered using a refractive LiquidGlassLens floating over the vibrant background.',
+        ),
+        actions: [
+          LiquidGlassButton(
+            label: 'Cancel',
+            onPressed: () => Navigator.of(context).pop(),
+          ),
+          LiquidGlassButton(
+            label: 'Confirm',
+            style: LiquidGlassButton.defaultStyle.copyWith(
+              appearance: const LiquidGlassAppearance(color: Color(0x607C5CFF)),
+            ),
+            onPressed: () {
+              Navigator.of(context).pop();
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(content: Text('Action Confirmed!')),
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+
+  void _openCustomDialog() {
+    showLiquidGlassDialog(
+      context: context,
+      builder: (context) => LiquidGlassDialog(
+        width: 320,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(Icons.shield_moon_rounded, size: 48, color: Color(0xFF5BC0FF)),
+            const SizedBox(height: 12),
+            const Text(
+              'Custom Glass Modal',
+              style: TextStyle(fontSize: 20, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Compose any arbitrary Flutter widgets inside LiquidGlassDialog for custom glass popups.',
+              textAlign: TextAlign.center,
+              style: TextStyle(color: Colors.white.withAlpha(200), fontSize: 13.5),
+            ),
+            const SizedBox(height: 20),
+            LiquidGlassButton(
+              label: 'Close Modal',
+              width: double.infinity,
+              onPressed: () => Navigator.of(context).pop(),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  static const List<_CardData> _cards = [
+    _CardData(
+      title: 'Neon Aurora Glow',
+      subtitle: 'Vibrant indigo & violet backdrop layers',
+      icon: Icons.palette_rounded,
+      gradient: [Color(0xFF7C5CFF), Color(0xFF4527A0)],
+    ),
+    _CardData(
+      title: 'Emerald Prism',
+      subtitle: 'Refracting deep teal & emerald light',
+      icon: Icons.diamond_rounded,
+      gradient: [Color(0xFF2DD4BF), Color(0xFF0D9488)],
+    ),
+    _CardData(
+      title: 'Sunset Crimson',
+      subtitle: 'Warm rose & coral chromatic dispersion',
+      icon: Icons.wb_sunny_rounded,
+      gradient: [Color(0xFFFF5C8A), Color(0xFF9D174D)],
+    ),
+    _CardData(
+      title: 'Electric Amber',
+      subtitle: 'High contrast optical edge highlighting',
+      icon: Icons.bolt_rounded,
+      gradient: [Color(0xFFFFB020), Color(0xFFB45309)],
+    ),
+    _CardData(
+      title: 'Oceanic Sapphire',
+      subtitle: 'Deep azure refraction with caustics',
+      icon: Icons.water_drop_rounded,
+      gradient: [Color(0xFF4FB3FF), Color(0xFF1D4ED8)],
+    ),
+    _CardData(
+      title: 'Cosmic Nebula',
+      subtitle: 'Multi-layer metaball glass blending',
+      icon: Icons.auto_awesome_rounded,
+      gradient: [Color(0xFFC084FC), Color(0xFF6B21A8)],
+    ),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return LiquidGlassScaffold(
+      appBar: LiquidGlassAppBar(
+        title: const Text('FAB & Dialog Showcase'),
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back_rounded, color: Colors.white),
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+      ),
+      body: Stack(
+        fit: StackFit.expand,
+        children: [
+          // Deep background gradient base
+          const DecoratedBox(
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                begin: Alignment.topLeft,
+                end: Alignment.bottomRight,
+                colors: [Color(0xFF0B0A12), Color(0xFF16112C), Color(0xFF2B1446)],
+              ),
+            ),
+          ),
+          Positioned(
+            top: 40,
+            left: -40,
+            child: Container(
+              width: 280,
+              height: 280,
+              decoration: const BoxDecoration(
+                shape: BoxShape.circle,
+                color: Color(0x507C5CFF),
+              ),
+            ),
+          ),
+          Positioned(
+            top: 300,
+            right: -60,
+            child: Container(
+              width: 300,
+              height: 300,
+              decoration: const BoxDecoration(
+                shape: BoxShape.circle,
+                color: Color(0x50FF5C8A),
+              ),
+            ),
+          ),
+          // Scrollable content feed
+          ScrollConfiguration(
+            behavior: const MaterialScrollBehavior().copyWith(overscroll: false),
+            child: ListView(
+              padding: const EdgeInsets.fromLTRB(20, 160, 20, 140),
+              children: [
+                const Text(
+                  'Scrollable Glass Feed',
+                  style: TextStyle(
+                    fontSize: 26,
+                    fontWeight: FontWeight.w800,
+                    color: Colors.white,
+                    letterSpacing: -0.5,
+                  ),
+                ),
+                const SizedBox(height: 6),
+                Text(
+                  'Scroll the content up and down. The floating FAB and dialog refract the colorful cards moving underneath in real time.',
+                  style: TextStyle(
+                    fontSize: 14,
+                    color: Colors.white.withAlpha(180),
+                    height: 1.35,
+                  ),
+                ),
+                const SizedBox(height: 24),
+
+                // Control action bar
+                Wrap(
+                  spacing: 12,
+                  runSpacing: 12,
+                  alignment: WrapAlignment.center,
+                  children: [
+                    LiquidGlassButton(
+                      label: _useExtendedFab ? 'Icon FAB' : 'Extended FAB',
+                      icon: Icons.swap_horiz_rounded,
+                      onPressed: () => setState(() => _useExtendedFab = !_useExtendedFab),
+                    ),
+                    LiquidGlassButton(
+                      label: 'Alert Dialog',
+                      icon: Icons.add_alert_rounded,
+                      style: LiquidGlassButton.defaultStyle.copyWith(
+                        appearance: const LiquidGlassAppearance(color: Color(0x407C5CFF)),
+                      ),
+                      onPressed: _openAlertDialog,
+                    ),
+                    LiquidGlassButton(
+                      label: 'Custom Dialog',
+                      icon: Icons.widgets_rounded,
+                      style: LiquidGlassButton.defaultStyle.copyWith(
+                        appearance: const LiquidGlassAppearance(color: Color(0x405BC0FF)),
+                      ),
+                      onPressed: _openCustomDialog,
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 32),
+
+                // Vibrant scrollable cards
+                for (final card in _cards) ...[
+                  _VibrantCard(data: card),
+                  const SizedBox(height: 16),
+                ],
+              ],
+            ),
+          ),
+        ],
+      ),
+      floatingActionButton: _useExtendedFab
+          ? LiquidGlassFab.extended(
+              icon: Icons.add_rounded,
+              label: const Text('New Action'),
+              onPressed: _openAlertDialog,
+            )
+          : LiquidGlassFab(
+              icon: Icons.add_rounded,
+              onPressed: _openAlertDialog,
+            ),
+    );
+  }
+}
+
+class _CardData {
+  final String title;
+  final String subtitle;
+  final IconData icon;
+  final List<Color> gradient;
+
+  const _CardData({
+    required this.title,
+    required this.subtitle,
+    required this.icon,
+    required this.gradient,
+  });
+}
+
+class _VibrantCard extends StatelessWidget {
+  final _CardData data;
+
+  const _VibrantCard({required this.data});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.all(20),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(24),
+        gradient: LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: [
+            data.gradient.first.withAlpha(220),
+            data.gradient.last.withAlpha(180),
+          ],
+        ),
+        boxShadow: [
+          BoxShadow(
+            color: data.gradient.first.withAlpha(80),
+            blurRadius: 16,
+            offset: const Offset(0, 8),
+          ),
+        ],
+        border: Border.all(color: Colors.white.withAlpha(40), width: 1.2),
+      ),
+      child: Row(
+        children: [
+          Container(
+            width: 56,
+            height: 56,
+            decoration: BoxDecoration(
+              color: Colors.white.withAlpha(40),
+              borderRadius: BorderRadius.circular(18),
+            ),
+            child: Icon(data.icon, color: Colors.white, size: 28),
+          ),
+          const SizedBox(width: 16),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  data.title,
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontSize: 17,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  data.subtitle,
+                  style: TextStyle(
+                    color: Colors.white.withAlpha(200),
+                    fontSize: 13,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const Icon(Icons.arrow_forward_ios_rounded, color: Colors.white70, size: 18),
+        ],
+      ),
+    );
+  }
+}

--- a/example/lib/gallery.dart
+++ b/example/lib/gallery.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'control_center_page.dart';
 import 'corner_style_page.dart';
+import 'fab_dialog_demo.dart';
 import 'lens_image_page.dart';
 import 'liquid_menu_page.dart';
 import 'nav_jelly_tuner.dart';
@@ -101,6 +102,13 @@ class HomePage extends StatelessWidget {
       icon: Icons.toggle_on_rounded,
       gradient: const [Color(0xFF2DD4BF), Color(0xFF0E8C7E)],
       builder: (_) => const SliderTogglePage(),
+    ),
+    _Destination(
+      title: 'FAB & Alert Dialog',
+      subtitle: 'Liquid glass FABs and animated glass alert dialogs',
+      icon: Icons.add_alert_rounded,
+      gradient: const [Color(0xFFFF7A00), Color(0xFFFF0055)],
+      builder: (_) => const FabAndDialogDemoPage(),
     ),
     _Destination(
       title: 'Corner Styles',

--- a/example/lib/scaffold_demo.dart
+++ b/example/lib/scaffold_demo.dart
@@ -135,6 +135,28 @@ class _ScaffoldDemoState extends State<ScaffoldDemo> {
         pillStyle: navPillStyle(navTuning),
         width: 320,
       ),
+      floatingActionButton: LiquidGlassFab.extended(
+        icon: Icons.auto_awesome_rounded,
+        label: const Text('Show Dialog'),
+        onPressed: () {
+          showLiquidGlassDialog(
+            context: context,
+            builder: (context) => LiquidGlassAlertDialog(
+              icon: const Icon(Icons.auto_awesome_rounded, color: Color(0xFF7C5CFF)),
+              title: const Text('Liquid Glass Dialog'),
+              content: const Text(
+                'This alert dialog is rendered using a refractive LiquidGlassLens floating seamlessly over the backdrop.',
+              ),
+              actions: [
+                LiquidGlassButton(
+                  label: 'Dismiss',
+                  onPressed: () => Navigator.of(context).pop(),
+                ),
+              ],
+            ),
+          );
+        },
+      ),
     );
   }
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -105,15 +105,15 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "3.3.0"
+    version: "3.3.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
@@ -126,10 +126,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   path:
     dependency: transitive
     description:
@@ -187,10 +187,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.9"
+    version: "0.7.11"
   vector_math:
     dependency: transitive
     description:
@@ -208,5 +208,5 @@ packages:
     source: hosted
     version: "14.3.0"
 sdks:
-  dart: ">=3.9.0-0 <4.0.0"
+  dart: ">=3.10.0-0 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/lib/liquid_glass_easy.dart
+++ b/lib/liquid_glass_easy.dart
@@ -44,6 +44,10 @@ export 'package:liquid_glass_easy/src/widgets/utils/liquid_glass_jelly_config.da
 // Generic glass UI atoms a developer composes into their app.
 // Each is a single LiquidGlass lens placed in a LiquidGlassView.
 export 'package:liquid_glass_easy/src/widgets/components/liquid_glass_button.dart';
+// Floating action button (circular FAB & extended FAB).
+export 'package:liquid_glass_easy/src/widgets/components/liquid_glass_fab.dart';
+// Dialogs & dialog presenter helper.
+export 'package:liquid_glass_easy/src/widgets/components/liquid_glass_dialog.dart';
 // Jelly: a reusable squash/stretch wrapper driven by a 1-D value — the
 // slider/nav-bar jelly physics exposed as a drop-in widget.
 export 'package:liquid_glass_easy/src/widgets/components/liquid_glass_jelly.dart';

--- a/lib/src/widgets/components/liquid_glass_dialog.dart
+++ b/lib/src/widgets/components/liquid_glass_dialog.dart
@@ -1,0 +1,364 @@
+import 'package:flutter/material.dart';
+
+import '../lens/liquid_glass_lens.dart';
+import '../liquid_glass_config.dart';
+import '../liquid_glass_style.dart';
+import '../utils/liquid_glass_blur.dart';
+import '../utils/liquid_glass_border_mode.dart';
+import '../utils/liquid_glass_shape.dart';
+
+/// Displays a liquid glass dialog over the current route.
+///
+/// Uses [showGeneralDialog] with a tuned scale + fade modal animation
+/// to present [LiquidGlassAlertDialog] or custom [LiquidGlassDialog] widgets.
+///
+/// ```dart
+/// showLiquidGlassDialog(
+///   context: context,
+///   builder: (context) => LiquidGlassAlertDialog(
+///     title: const Text('Delete Item?'),
+///     content: const Text('This action cannot be undone.'),
+///     actions: [
+///       LiquidGlassButton(
+///         label: 'Cancel',
+///         onPressed: () => Navigator.of(context).pop(),
+///       ),
+///       LiquidGlassButton(
+///         label: 'Delete',
+///         style: LiquidGlassButton.defaultStyle.copyWith(
+///           appearance: const LiquidGlassAppearance(color: Color(0x60FF3B30)),
+///         ),
+///         onPressed: () => Navigator.of(context).pop(true),
+///       ),
+///     ],
+///   ),
+/// );
+/// ```
+Future<T?> showLiquidGlassDialog<T>({
+  required BuildContext context,
+  required WidgetBuilder builder,
+  bool barrierDismissible = true,
+  Color barrierColor = const Color(0x80000000),
+  String? barrierLabel,
+  bool useSafeArea = true,
+  bool useRootNavigator = true,
+  RouteSettings? routeSettings,
+  Offset? anchorPoint,
+  Duration transitionDuration = const Duration(milliseconds: 350),
+  Curve transitionCurve = const Cubic(0.16, 1.0, 0.3, 1.0),
+  Curve reverseTransitionCurve = const Cubic(0.7, 0.0, 0.84, 0.0),
+}) {
+  assert(debugCheckHasMaterialLocalizations(context));
+
+  final CapturedThemes themes = InheritedTheme.capture(
+    from: context,
+    to: Navigator.of(
+      context,
+      rootNavigator: useRootNavigator,
+    ).context,
+  );
+
+  return showGeneralDialog<T>(
+    context: context,
+    barrierDismissible: barrierDismissible,
+    barrierColor: barrierColor,
+    barrierLabel: barrierLabel ?? MaterialLocalizations.of(context).modalBarrierDismissLabel,
+    useRootNavigator: useRootNavigator,
+    routeSettings: routeSettings,
+    anchorPoint: anchorPoint,
+    transitionDuration: transitionDuration,
+    pageBuilder: (buildContext, animation, secondaryAnimation) {
+      final Widget page = builder(buildContext);
+      Widget dialog = themes.wrap(page);
+      if (useSafeArea) {
+        dialog = SafeArea(child: dialog);
+      }
+      return dialog;
+    },
+    transitionBuilder: (context, animation, secondaryAnimation, child) {
+      final CurvedAnimation curvedAnimation = CurvedAnimation(
+        parent: animation,
+        curve: transitionCurve,
+        reverseCurve: reverseTransitionCurve,
+      );
+
+      return FadeTransition(
+        opacity: CurvedAnimation(
+          parent: animation,
+          curve: const Interval(0.0, 0.8, curve: Curves.easeOut),
+          reverseCurve: const Interval(0.2, 1.0, curve: Curves.easeIn),
+        ),
+        child: ScaleTransition(
+          scale: Tween<double>(begin: 0.84, end: 1.0).animate(curvedAnimation),
+          child: child,
+        ),
+      );
+    },
+  );
+}
+
+/// A generic dialog container rendered as a liquid glass surface.
+class LiquidGlassDialog extends StatelessWidget {
+  /// Custom inner content widget.
+  final Widget child;
+
+  /// Maximum width of the dialog card.
+  final double width;
+
+  /// Inner padding surrounding the child.
+  final EdgeInsetsGeometry padding;
+
+  /// Glass style (shape + appearance + refraction).
+  final LiquidGlassStyle? style;
+
+  /// Whether the dialog lens is visible.
+  final bool visibility;
+
+  /// Alignment of the dialog on screen.
+  final AlignmentGeometry alignment;
+
+  static const LiquidGlassAppearance _defaultAppearance = LiquidGlassAppearance(
+    color: Color(0x28FFFFFF), // white frost, alpha 40
+    blur: LiquidGlassBlur(sigmaX: 8, sigmaY: 8),
+  );
+
+  static const LiquidGlassRefraction _defaultRefraction = LiquidGlassRefraction(
+    distortion: 0.08,
+    distortionWidth: 36,
+    chromaticAberration: 0.002,
+  );
+
+  /// Default glass look for dialogs.
+  static const LiquidGlassStyle defaultStyle = LiquidGlassStyle(
+    appearance: _defaultAppearance,
+    refraction: _defaultRefraction,
+  );
+
+  const LiquidGlassDialog({
+    super.key,
+    required this.child,
+    this.width = 340.0,
+    this.padding = const EdgeInsets.all(24.0),
+    this.style,
+    this.visibility = true,
+    this.alignment = Alignment.center,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final LiquidGlassStyle resolved = defaultStyle.merge(style);
+    final LiquidGlassShape effectiveShape = resolved.shape ??
+        LiquidGlassShape.roundedRectangle(
+          cornerRadius: 28,
+          borderWidth: 1.2,
+          lightIntensity: 1.2,
+          lightDirection: 80,
+          borderType: const OpticalBorder(
+            borderSaturation: 1.3,
+            ambientIntensity: 1.0,
+            borderSolidity: 0.4,
+          ),
+        );
+
+    return Align(
+      alignment: alignment,
+      child: ConstrainedBox(
+        constraints: BoxConstraints(maxWidth: width),
+        child: LiquidGlassLens(
+          style: LiquidGlassStyle(
+            shape: effectiveShape,
+            appearance: resolved.appearance,
+            refraction: resolved.refraction,
+          ),
+          visibility: visibility,
+          child: Material(
+            color: Colors.transparent,
+            child: Padding(
+              padding: padding,
+              child: DefaultTextStyle(
+                style: const TextStyle(
+                  color: Colors.white,
+                  decoration: TextDecoration.none,
+                ),
+                child: child,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+/// An alert dialog rendered with a liquid glass surface.
+///
+/// Features standard Material 3 dialog slots (`icon`, `title`, `content`, `actions`)
+/// elevated on top of a frosted refractive liquid glass lens.
+class LiquidGlassAlertDialog extends StatelessWidget {
+  /// Optional leading icon above the title.
+  final Widget? icon;
+
+  /// Icon color if a plain Icon is provided.
+  final Color? iconColor;
+
+  /// Padding around the icon.
+  final EdgeInsetsGeometry iconPadding;
+
+  /// Title widget (or Text).
+  final Widget? title;
+
+  /// Padding around the title.
+  final EdgeInsetsGeometry titlePadding;
+
+  /// Default text style for title.
+  final TextStyle? titleTextStyle;
+
+  /// Content widget (body).
+  final Widget? content;
+
+  /// Padding around content widget.
+  final EdgeInsetsGeometry contentPadding;
+
+  /// Default text style for content.
+  final TextStyle? contentTextStyle;
+
+  /// List of action widgets (e.g. [LiquidGlassButton] or standard buttons).
+  final List<Widget>? actions;
+
+  /// Padding around action buttons row/column.
+  final EdgeInsetsGeometry actionsPadding;
+
+  /// Horizontal alignment of actions.
+  final MainAxisAlignment actionsAlignment;
+
+  /// Overflow alignment when actions do not fit horizontally.
+  final OverflowBarAlignment actionsOverflowAlignment;
+
+  /// Direction of actions when overflowing.
+  final VerticalDirection actionsOverflowDirection;
+
+  /// Spacing between action buttons when overflowing.
+  final double? actionsOverflowButtonSpacing;
+
+  /// Glass style descriptor.
+  final LiquidGlassStyle? style;
+
+  /// Dialog max width.
+  final double width;
+
+  /// Whether title and content should be scrollable.
+  final bool scrollable;
+
+  /// Whether the dialog lens is visible.
+  final bool visibility;
+
+  const LiquidGlassAlertDialog({
+    super.key,
+    this.icon,
+    this.iconColor,
+    this.iconPadding = const EdgeInsets.only(bottom: 16.0),
+    this.title,
+    this.titlePadding = const EdgeInsets.only(bottom: 12.0),
+    this.titleTextStyle,
+    this.content,
+    this.contentPadding = const EdgeInsets.only(bottom: 24.0),
+    this.contentTextStyle,
+    this.actions,
+    this.actionsPadding = EdgeInsets.zero,
+    this.actionsAlignment = MainAxisAlignment.end,
+    this.actionsOverflowAlignment = OverflowBarAlignment.end,
+    this.actionsOverflowDirection = VerticalDirection.down,
+    this.actionsOverflowButtonSpacing,
+    this.style,
+    this.width = 340.0,
+    this.scrollable = false,
+    this.visibility = true,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final ThemeData theme = Theme.of(context);
+
+    final TextStyle effectiveTitleStyle = titleTextStyle ??
+        theme.textTheme.headlineSmall?.copyWith(
+          color: Colors.white,
+          fontWeight: FontWeight.w600,
+        ) ??
+        const TextStyle(
+          color: Colors.white,
+          fontSize: 20,
+          fontWeight: FontWeight.w600,
+        );
+
+    final TextStyle effectiveContentStyle = contentTextStyle ??
+        theme.textTheme.bodyMedium?.copyWith(
+          color: Colors.white.withAlpha(220),
+          fontSize: 14.5,
+          height: 1.4,
+        ) ??
+        TextStyle(
+          color: Colors.white.withAlpha(220),
+          fontSize: 14.5,
+          height: 1.4,
+        );
+
+    Widget dialogContent = Column(
+      mainAxisSize: MainAxisSize.min,
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        if (icon != null)
+          Padding(
+            padding: iconPadding,
+            child: IconTheme.merge(
+              data: IconThemeData(
+                color: iconColor ?? Colors.white,
+                size: 28.0,
+              ),
+              child: Center(child: icon),
+            ),
+          ),
+        if (title != null)
+          Padding(
+            padding: titlePadding,
+            child: DefaultTextStyle(
+              style: effectiveTitleStyle,
+              textAlign: icon == null ? TextAlign.start : TextAlign.center,
+              child: title!,
+            ),
+          ),
+        if (content != null)
+          Padding(
+            padding: contentPadding,
+            child: DefaultTextStyle(
+              style: effectiveContentStyle,
+              textAlign: icon == null ? TextAlign.start : TextAlign.center,
+              child: content!,
+            ),
+          ),
+        if (actions != null && actions!.isNotEmpty)
+          Padding(
+            padding: actionsPadding,
+            child: OverflowBar(
+              alignment: actionsAlignment,
+              overflowAlignment: actionsOverflowAlignment,
+              overflowDirection: actionsOverflowDirection,
+              overflowSpacing: actionsOverflowButtonSpacing ?? 8.0,
+              spacing: 12.0,
+              children: actions!,
+            ),
+          ),
+      ],
+    );
+
+    if (scrollable) {
+      dialogContent = SingleChildScrollView(child: dialogContent);
+    }
+
+    return LiquidGlassDialog(
+      width: width,
+      style: style,
+      visibility: visibility,
+      child: dialogContent,
+    );
+  }
+}

--- a/lib/src/widgets/components/liquid_glass_fab.dart
+++ b/lib/src/widgets/components/liquid_glass_fab.dart
@@ -1,0 +1,232 @@
+import 'package:flutter/material.dart';
+
+import '../lens/liquid_glass_lens.dart';
+import '../liquid_glass_config.dart';
+import '../liquid_glass_style.dart';
+import '../utils/liquid_glass_blur.dart';
+import '../utils/liquid_glass_border_mode.dart';
+import '../utils/liquid_glass_shape.dart';
+
+/// A floating action button (FAB) rendered as liquid glass.
+///
+/// Supports standard circular FABs, custom child FABs, and extended FABs
+/// with an icon and label via [LiquidGlassFab.extended].
+///
+/// Drop it anywhere in your layout or pass it to `LiquidGlassScaffold`'s
+/// `floatingActionButton` slot.
+///
+/// ```dart
+/// LiquidGlassFab(
+///   icon: Icons.add,
+///   onPressed: () {},
+/// )
+///
+/// LiquidGlassFab.extended(
+///   icon: Icons.edit,
+///   label: const Text('Compose'),
+///   onPressed: () {},
+/// )
+/// ```
+class LiquidGlassFab extends StatelessWidget {
+  /// Standard FAB constructor (circular or custom child).
+  const LiquidGlassFab({
+    super.key,
+    this.icon,
+    this.child,
+    this.onPressed,
+    this.size = 56.0,
+    this.padding = const EdgeInsets.all(16),
+    this.style,
+    this.visibility = true,
+    this.foregroundColor = Colors.white,
+    this.iconSize = 24.0,
+    this.heroTag,
+    this.tooltip,
+    this.elevation = 0.0,
+  })  : label = null,
+        height = null,
+        width = null,
+        isExtended = false,
+        assert(icon != null || child != null, 'Either icon or child must be provided.');
+
+  /// Extended FAB constructor with label and optional icon.
+  const LiquidGlassFab.extended({
+    super.key,
+    required this.label,
+    this.icon,
+    this.onPressed,
+    double height = 48.0,
+    this.width,
+    this.padding = const EdgeInsets.symmetric(horizontal: 20, vertical: 12),
+    this.style,
+    this.visibility = true,
+    this.foregroundColor = Colors.white,
+    this.iconSize = 20.0,
+    this.heroTag,
+    this.tooltip,
+    this.elevation = 0.0,
+  })  : child = null,
+        height = height,
+        size = height,
+        isExtended = true;
+
+  /// Optional icon for regular or extended FAB.
+  final IconData? icon;
+
+  /// Custom child widget inside standard FAB.
+  final Widget? child;
+
+  /// Label widget for extended FAB.
+  final Widget? label;
+
+  /// Tap callback.
+  final VoidCallback? onPressed;
+
+  /// Size (diameter) of standard circular FAB.
+  final double size;
+
+  /// Explicit height for extended FAB.
+  final double? height;
+
+  /// Explicit width for extended FAB.
+  final double? width;
+
+  /// Inner padding around icon/label.
+  final EdgeInsetsGeometry padding;
+
+  /// Glass look descriptor (shape + appearance + refraction).
+  final LiquidGlassStyle? style;
+
+  /// Whether the FAB is shown; toggling animates glass in/out.
+  final bool visibility;
+
+  /// Foreground color for icon/text.
+  final Color foregroundColor;
+
+  /// Icon size.
+  final double iconSize;
+
+  /// Optional Hero tag for route transitions.
+  final Object? heroTag;
+
+  /// Optional tooltip string.
+  final String? tooltip;
+
+  /// Optional shadow elevation behind the lens.
+  final double elevation;
+
+  /// Whether this is an extended FAB layout.
+  final bool isExtended;
+
+  static const LiquidGlassAppearance _defaultAppearance = LiquidGlassAppearance(
+    color: Color(0x1CFFFFFF), // white, alpha 28
+    blur: LiquidGlassBlur(sigmaX: 4, sigmaY: 4),
+  );
+
+  static const LiquidGlassRefraction _defaultRefraction = LiquidGlassRefraction(
+    distortion: 0.08,
+    distortionWidth: 28,
+    chromaticAberration: 0.002,
+  );
+
+  /// The tuned default look for liquid glass FAB.
+  static const LiquidGlassStyle defaultStyle = LiquidGlassStyle(
+    appearance: _defaultAppearance,
+    refraction: _defaultRefraction,
+  );
+
+  @override
+  Widget build(BuildContext context) {
+    final LiquidGlassStyle resolved = defaultStyle.merge(style);
+
+    final double effectiveHeight = isExtended ? (height ?? 48.0) : size;
+    final double? effectiveWidth = isExtended ? width : size;
+
+    final LiquidGlassShape effectiveShape = resolved.shape ??
+        LiquidGlassShape.roundedRectangle(
+          cornerRadius: effectiveHeight / 2,
+          borderWidth: 1.2,
+          lightIntensity: 1.2,
+          lightDirection: 80,
+          borderType: const OpticalBorder(
+            borderSaturation: 1.3,
+            ambientIntensity: 1.0,
+            borderSolidity: 0.4,
+          ),
+        );
+
+    Widget content;
+    if (child != null) {
+      content = child!;
+    } else if (isExtended) {
+      content = Row(
+        mainAxisSize: MainAxisSize.min,
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          if (icon != null) ...[
+            Icon(icon, color: foregroundColor, size: iconSize),
+            const SizedBox(width: 8),
+          ],
+          DefaultTextStyle.merge(
+            style: TextStyle(
+              color: foregroundColor,
+              fontSize: 15,
+              fontWeight: FontWeight.w600,
+              decoration: TextDecoration.none,
+            ),
+            child: label!,
+          ),
+        ],
+      );
+    } else {
+      content = Icon(icon, color: foregroundColor, size: iconSize);
+    }
+
+    Widget result = SizedBox(
+      width: effectiveWidth,
+      height: effectiveHeight,
+      child: LiquidGlassLens(
+        style: LiquidGlassStyle(
+          shape: effectiveShape,
+          appearance: resolved.appearance,
+          refraction: resolved.refraction,
+        ),
+        visibility: visibility,
+        child: Material(
+          color: Colors.transparent,
+          elevation: elevation,
+          borderRadius: BorderRadius.circular(
+            liquidGlassClipCornerRadius(effectiveShape),
+          ),
+          child: InkWell(
+            borderRadius: BorderRadius.circular(
+              liquidGlassClipCornerRadius(effectiveShape),
+            ),
+            onTap: onPressed,
+            child: Padding(
+              padding: padding,
+              child: Center(
+                widthFactor: effectiveWidth == null ? 1.0 : null,
+                heightFactor: 1.0,
+                child: content,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    if (tooltip != null) {
+      result = Tooltip(message: tooltip, child: result);
+    }
+
+    if (heroTag != null) {
+      result = Hero(tag: heroTag!, child: result);
+    }
+
+    return result;
+  }
+}
+
+/// Alias for [LiquidGlassFab].
+typedef LiquidGlassFloatingActionButton = LiquidGlassFab;

--- a/lib/src/widgets/components/liquid_glass_scaffold.dart
+++ b/lib/src/widgets/components/liquid_glass_scaffold.dart
@@ -62,6 +62,12 @@ class LiquidGlassScaffold extends StatelessWidget {
   /// [LiquidGlassTabBarAction].
   final Widget? bottomNavigationBarAction;
 
+  /// A floating action button, typically a [LiquidGlassFab].
+  final Widget? floatingActionButton;
+
+  /// Position of [floatingActionButton]. Defaults to bottom-right.
+  final AlignmentGeometry floatingActionButtonAlignment;
+
   /// Extra free-floating glass widgets composited between the [body] and
   /// the bars. An escape hatch — position each with your own
   /// `Align`/`Positioned`.
@@ -110,6 +116,8 @@ class LiquidGlassScaffold extends StatelessWidget {
     this.appBar,
     this.bottomNavigationBar,
     this.bottomNavigationBarAction,
+    this.floatingActionButton,
+    this.floatingActionButtonAlignment = Alignment.bottomRight,
     this.lenses = const [],
     this.backgroundColor,
     this.safeArea = true,
@@ -147,9 +155,13 @@ class LiquidGlassScaffold extends StatelessWidget {
       );
     }
 
-    final Widget background = backgroundColor == null
+    final Widget rawBackground = backgroundColor == null
         ? body
         : ColoredBox(color: backgroundColor!, child: body);
+    final Widget background = Material(
+      type: MaterialType.transparency,
+      child: rawBackground,
+    );
 
     return LiquidGlassView(
       controller: controller,
@@ -214,6 +226,17 @@ class LiquidGlassScaffold extends StatelessWidget {
               bottom: pad.bottom + navMargin.bottom,
               right: actionMargin,
               child: bottomNavigationBarAction!,
+            ),
+          if (floatingActionButton != null)
+            Positioned(
+              top: pad.top + actionMargin,
+              bottom: pad.bottom + actionMargin + (bottomNavigationBar != null ? 64 : 0),
+              left: actionMargin,
+              right: actionMargin,
+              child: Align(
+                alignment: floatingActionButtonAlignment,
+                child: floatingActionButton!,
+              ),
             ),
         ],
       ),


### PR DESCRIPTION
### Summary of Additions
- **`LiquidGlassFab`**: Floating Action Button (circular and extended variants) powered by `LiquidGlassLens`.
- **`LiquidGlassAlertDialog` & `LiquidGlassDialog`**: Refractive glass alert dialogs with slot controls and `showLiquidGlassDialog` presenter (features fluid iOS cubic spring transition).
- **Scaffold Integration**: Added `floatingActionButton` and `floatingActionButtonAlignment` to `LiquidGlassScaffold`.
- **Gallery Showcase**: Added `FabAndDialogDemoPage` showcase in `example/lib/gallery.dart`.